### PR TITLE
feat: Add ClickedPoint Panel

### DIFF
--- a/icons/classes/ClickedPoint.svg
+++ b/icons/classes/ClickedPoint.svg
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   id="svg3851"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="PublishPoint.svg"
+   inkscape:export-filename="/work/gossow/rviz/rviz/icons/visibility.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs3853">
+    <linearGradient
+       id="linearGradient3841">
+      <stop
+         id="stop3843"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.34984758"
+         id="stop3845" />
+      <stop
+         id="stop3849"
+         offset="0.5454545"
+         style="stop-color:#e8e8e8;stop-opacity:1;" />
+      <stop
+         id="stop3847"
+         offset="1"
+         style="stop-color:#252525;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3824">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3826" />
+      <stop
+         id="stop3832"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d2d2d2;stop-opacity:1;"
+         offset="1"
+         id="stop3828" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#e85537;stop-opacity:1;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         style="stop-color:#433613;stop-opacity:1;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect3829"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m 4.8980822,-0.72049866 6.1888208,0"
+       bendpath2="M 11.086903,-0.72049866 16.270482,14.741843"
+       bendpath3="M -0.25926539,14.751544 16.270482,14.741891"
+       bendpath4="M 4.8980822,-0.72049866 -0.25926539,14.751544"
+       bendpath3-nodetypes="cc"
+       bendpath4-nodetypes="cc"
+       bendpath2-nodetypes="cc" />
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect3819"
+       is_visible="true"
+       yy="true"
+       xx="true"
+       bendpath1="m -11,0.5 6.0000002,0"
+       bendpath2="m -4.9999998,0.5 0,15"
+       bendpath3="m -11,15.5 6.0000002,0"
+       bendpath4="m -11,0.5 0,15" />
+    <linearGradient
+       id="linearGradient5756">
+      <stop
+         style="stop-color:#c8c8c8;stop-opacity:1;"
+         offset="0"
+         id="stop5758" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5760" />
+    </linearGradient>
+    <inkscape:path-effect
+       bendpath4-nodetypes="cc"
+       bendpath2-nodetypes="cc"
+       bendpath4="m 0.40934447,12.183659 c 5.22111233,-2.7860162 10.20346753,-2.563681 15.00000053,0"
+       bendpath3="m 15.409345,12.183659 0,-6.0000003"
+       bendpath2="m 0.40934447,6.1836587 c 5.17204473,-2.752717 10.16772953,-2.683658 15.00000053,0"
+       bendpath1="m 0.40934447,12.183659 0,-6.0000003"
+       xx="true"
+       yy="false"
+       is_visible="true"
+       id="path-effect5700"
+       effect="envelope" />
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect5673"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m 3.7040018,0.50188195 6.0000002,0"
+       bendpath2="m 9.704002,0.50188195 c 2.752717,5.17204475 2.683658,10.16772905 0,15.00000005"
+       bendpath3="m 3.7040018,15.501882 6.0000002,0"
+       bendpath4="m 3.7040018,0.50188195 c 2.7860161,5.22111235 2.5636809,10.20346705 0,15.00000005"
+       bendpath2-nodetypes="cc"
+       bendpath4-nodetypes="cc" />
+    <inkscape:path-effect
+       effect="bend_path"
+       id="path-effect5590"
+       is_visible="true"
+       bendpath="m 6.5,8 4,0"
+       prop_scale="1"
+       scale_y_rel="true"
+       vertical="false" />
+    <inkscape:path-effect
+       effect="vonkoch"
+       id="path-effect5588"
+       is_visible="true"
+       ref_path="m 6.5,8 4,0"
+       generator="m 6.5,15.5 1.3333333,0 m 1.3333334,0 1.3333333,0"
+       similar_only="false"
+       nbgenerations="1"
+       drawall="true"
+       maxComplexity="1000" />
+    <inkscape:path-effect
+       effect="rough_hatches"
+       id="path-effect5586"
+       is_visible="false"
+       direction="8.5,3 , 1,0"
+       dist_rdm="75;1"
+       growth="0"
+       do_bend="true"
+       bender="8.5,8 , 5,0"
+       bottom_edge_variation="1.5;1"
+       top_edge_variation="1.5;1"
+       bottom_tgt_variation="0;1"
+       top_tgt_variation="0;1"
+       scale_bf="1"
+       scale_bb="1"
+       scale_tf="1"
+       scale_tb="1"
+       top_smth_variation="0;1"
+       bottom_smth_variation="0;1"
+       fat_output="true"
+       stroke_width_top="1"
+       stroke_width_bottom="1"
+       front_thickness="1"
+       back_thickness="0.25" />
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect5582"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m 6.5,0.5 4,0"
+       bendpath2="m 10.5,0.5 0,15"
+       bendpath3="m 6.5,15.5 4,0"
+       bendpath4="m 6.5,0.5 0,15" />
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lend"
+       style="overflow:visible;">
+      <path
+         id="path4397"
+         style="font-size:12.0;fill-rule:evenodd;stroke-width:0.62500000;stroke-linejoin:round;"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) rotate(180) translate(1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lstart"
+       style="overflow:visible">
+      <path
+         id="path4394"
+         style="font-size:12.0;fill-rule:evenodd;stroke-width:0.62500000;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) translate(1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path4376"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;marker-start:none"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect5673-8"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m -1.9996646,0.50189386 6,0"
+       bendpath2="m 4.0003354,0.50189386 c 2.7527172,5.17204484 2.6836582,10.16772914 0,15.00000014"
+       bendpath3="m -1.9996646,15.501894 6,0"
+       bendpath4="m -1.9996646,0.50189386 c 2.7860161,5.22111244 2.5636809,10.20346714 0,15.00000014"
+       bendpath2-nodetypes="cc"
+       bendpath4-nodetypes="cc" />
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect5673-7"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m -11,0.5 6.0000002,0"
+       bendpath2="m -4.9999998,0.5 c 2.7527168,5.1720447 2.6836578,10.167729 0,15"
+       bendpath3="m -11,15.5 6.0000002,0"
+       bendpath4="m -11,0.5 c 2.7860161,5.2211123 2.5636809,10.203467 0,15"
+       bendpath2-nodetypes="cc"
+       bendpath4-nodetypes="cc" />
+    <inkscape:path-effect
+       effect="envelope"
+       id="path-effect5673-7-1"
+       is_visible="true"
+       yy="false"
+       xx="true"
+       bendpath1="m 3.8034148,0.59873227 6,0"
+       bendpath2="m 9.8034148,0.59873227 c 2.7527172,5.17204473 2.6836582,10.16772873 0,14.99999973"
+       bendpath3="m 3.8034148,15.598732 6,0"
+       bendpath4="m 3.8034148,0.59873227 c 2.7860159,5.22111233 2.5636807,10.20346673 0,14.99999973"
+       bendpath2-nodetypes="cc"
+       bendpath4-nodetypes="cc" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5756"
+       id="linearGradient5762"
+       x1="12"
+       y1="11.5"
+       x2="7.5"
+       y2="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.030301,0,0,1.030301,16.242408,-0.242408)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5756"
+       id="linearGradient3798"
+       x1="4"
+       y1="14"
+       x2="9"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3827"
+       id="linearGradient3835"
+       x1="8"
+       y1="2.75"
+       x2="8"
+       y2="15"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1111111,0,0,1.0666665,-0.88888889,-0.53333227)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="5.7172161"
+     inkscape:cy="4.1322253"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1247"
+     inkscape:window-height="1548"
+     inkscape:window-x="66"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5567"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.25px"
+       spacingy="0.25px" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid5569"
+       empspacing="8"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       color="#ff0000"
+       opacity="0.1254902" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3856">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       style="fill:url(#linearGradient3835);fill-opacity:1;stroke:none"
+       d="M 8,1.02e-6 C 5.2385762,1.02e-6 3,3.0430126 3,5.5172419 3,8.5172419 8,16 8,16 8,16 13,8.6103925 13,5.5862074 13,5.5621684 13,5.5412814 13,5.5172424 13,2.4701539 10.761423,1.02e-6 8,1.02e-6 z M 7.9652778,3.0068973 c 0.9204746,0 1.6666667,0.7410458 1.6666667,1.6551722 0,0.9141264 -0.7461921,1.6551723 -1.6666667,1.6551723 -0.9204746,0 -1.6666667,-0.7410459 -1.6666667,-1.6551723 0,-0.9141264 0.7461921,-1.6551722 1.6666667,-1.6551722 z"
+       id="path3033"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscssssssss" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer" />
+</svg>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rviz</name>
-  <version>1.12.15</version>
+  <version>1.12.16</version>
   <description>
      3D visualization tool for ROS.
   </description>

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -279,5 +279,10 @@
       Orthographic projection, seen from the top.
     </description>
   </class>
+  <class name="rviz/ClickedPoint" type="rviz::ClickedPointPanel" base_class_type="rviz::Panel">
+    <description>
+      A panel widget which shows the coordinates of the clicked point (published by rviz/PublishPoint tool).
+    </description>
+  </class>
 
 </library>

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCE_FILES
   view_controllers/fps_view_controller.cpp
   wrench_display.cpp
   wrench_visual.cpp
+  clicked_point_panel.cpp
 )
 
 add_library(${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME} ${SOURCE_FILES})

--- a/src/rviz/default_plugin/clicked_point_panel.cpp
+++ b/src/rviz/default_plugin/clicked_point_panel.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, Synapticon GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <QPainter>
+#include <QLineEdit>
+#include <QVBoxLayout>
+#include <QLabel>
+
+#include "clicked_point_panel.h"
+
+namespace rviz
+{
+ClickedPointPanel::ClickedPointPanel(QWidget* parent) : rviz::Panel(parent)
+{
+  QHBoxLayout* x_layout = new QHBoxLayout;
+  x_layout->addWidget(new QLabel("X:"));
+  x_line_edit_ = new QLineEdit;
+  x_layout->addWidget(x_line_edit_);
+
+  QHBoxLayout* y_layout = new QHBoxLayout;
+  y_layout->addWidget(new QLabel("Y:"));
+  y_line_edit_ = new QLineEdit;
+  y_layout->addWidget(y_line_edit_);
+
+  QHBoxLayout* z_layout = new QHBoxLayout;
+  z_layout->addWidget(new QLabel("Z:"));
+  z_line_edit_ = new QLineEdit;
+  z_layout->addWidget(z_line_edit_);
+
+  QVBoxLayout* layout = new QVBoxLayout;
+  layout->addLayout(x_layout);
+  layout->addLayout(y_layout);
+  layout->addLayout(z_layout);
+  setLayout(layout);
+  clicked_point_subscriber_ = nh_.subscribe("/clicked_point", 10, &ClickedPointPanel::clickedPointCallback, this);
+}
+
+void ClickedPointPanel::save(rviz::Config config) const
+{
+  rviz::Panel::save(config);
+}
+
+void ClickedPointPanel::clickedPointCallback(const geometry_msgs::PointStampedConstPtr& msg)
+{
+  x_line_edit_->setText(QString::number(msg->point.x));
+  y_line_edit_->setText(QString::number(msg->point.y));
+  z_line_edit_->setText(QString::number(msg->point.y));
+}
+
+void ClickedPointPanel::load(const rviz::Config& config)
+{
+  rviz::Panel::load(config);
+}
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(rviz::ClickedPointPanel, rviz::Panel)

--- a/src/rviz/default_plugin/clicked_point_panel.h
+++ b/src/rviz/default_plugin/clicked_point_panel.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, Synapticon GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SNCN_RVIZ_PLUGIN_CLICKED_POINT_PANEL_H
+#define SNCN_RVIZ_PLUGIN_CLICKED_POINT_PANEL_H
+
+#ifndef Q_MOC_RUN
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#endif
+
+#include <geometry_msgs/PointStamped.h>
+
+class QLineEdit;
+
+namespace rviz
+{
+class ClickedPointPanel : public rviz::Panel
+{
+  Q_OBJECT
+
+public:
+  ClickedPointPanel(QWidget *parent = 0);
+
+  virtual void load(const rviz::Config &config);
+  virtual void save(rviz::Config config) const;
+
+private:
+  void clickedPointCallback(const geometry_msgs::PointStampedConstPtr &msg);
+
+protected:
+  ros::Subscriber clicked_point_subscriber_;
+
+  ros::NodeHandle nh_;
+  QLineEdit *x_line_edit_;
+  QLineEdit *y_line_edit_;
+  QLineEdit *z_line_edit_;
+};
+}
+
+#endif


### PR DESCRIPTION
A simple panel has been added in order to decrease the complexity of using **rviz/PublishPoint** tool so that the coordinates of the clicked point will be shown in the panel and there will be no need to subscribe to `/clicked_point` topic anymore.

![screenshot from 2018-02-09 13-34-52](https://user-images.githubusercontent.com/2716644/36028106-0a91cd1a-0d9e-11e8-8974-316faafde9d1.png)